### PR TITLE
Use PAX format, but store in Xattrs

### DIFF
--- a/file/tarball.go
+++ b/file/tarball.go
@@ -69,8 +69,8 @@ func (t *TarballBuilder) addFile(tw *tar.Writer, name string, m *rmq.Message) er
 	header.Mode = 0644
 	header.ModTime = time.Now()
 	header.Format = tar.FormatPAX
-	header.PAXRecords = m.ToPAXRecords()
-	header.PAXRecords["RABBITIO.amqp.routingkey"] = m.RoutingKey
+	header.Xattrs = m.ToPAXRecords()
+	header.Xattrs["RABBITIO.amqp.routingkey"] = m.RoutingKey
 
 	if err := tw.WriteHeader(header); err != nil {
 		return err

--- a/file/tarball.go
+++ b/file/tarball.go
@@ -70,7 +70,7 @@ func (t *TarballBuilder) addFile(tw *tar.Writer, name string, m *rmq.Message) er
 	header.ModTime = time.Now()
 	header.Format = tar.FormatPAX
 	header.PAXRecords = m.ToPAXRecords()
-	header.PAXRecords["RABBITIO.amqp.routingKey"] = m.RoutingKey
+	header.PAXRecords["RABBITIO.amqp.routingkey"] = m.RoutingKey
 
 	if err := tw.WriteHeader(header); err != nil {
 		return err

--- a/rmq/message.go
+++ b/rmq/message.go
@@ -53,7 +53,7 @@ func (m *Message) ToPAXRecords() map[string]string {
 		case string:
 			headerType = "string"
 		}
-		pax[fmt.Sprintf("RABBITIO.amqp.Headers.%s.%s", headerType, k)] = fmt.Sprintf("%v", v)
+		pax[fmt.Sprintf("RABBITIO.amqp.headers.%s.%s", headerType, k)] = fmt.Sprintf("%v", v)
 	}
 	return pax
 }
@@ -69,11 +69,11 @@ func NewMessage(bytes []byte, xattr map[string]string) *Message {
 	for k, v := range xattr {
 
 		switch {
-		case k == "RABBITIO.amqp.routingKey":
+		case k == "RABBITIO.amqp.routingkey":
 			routingKey = v
-		case strings.HasPrefix(k, "RABBITIO.amqp.Headers."):
+		case strings.HasPrefix(k, "RABBITIO.amqp.headers."):
 			// th is now [type, header]
-			th := strings.SplitN(strings.TrimPrefix(k, "RABBITIO.amqp.Headers."), ".", 2)
+			th := strings.SplitN(strings.TrimPrefix(k, "RABBITIO.amqp.headers."), ".", 2)
 			headerType := th[0]
 			header := strings.Join(th[1:], ".")
 

--- a/rmq/message_test.go
+++ b/rmq/message_test.go
@@ -22,17 +22,19 @@ import (
 )
 
 var (
-	myStringHeader  = "RABBITIO.amqp.Headers.string.myStringHeader"
-	myInt32Header   = "RABBITIO.amqp.Headers.int.myInt32Header"
-	myInt64Header   = "RABBITIO.amqp.Headers.int.myInt64Header"
-	myFloat32Header = "RABBITIO.amqp.Headers.float.myFloat32Header"
-	myFloat64Header = "RABBITIO.amqp.Headers.float.myFloat64Header"
-	myBoolHeader    = "RABBITIO.amqp.Headers.bool.myBoolHeader"
+	myStringHeader   = "RABBITIO.amqp.headers.string.myStringHeader"
+	myStringEqHeader = "RABBITIO.amqp.headers.string.myStringEqHeader"
+	myInt32Header    = "RABBITIO.amqp.headers.int.myInt32Header"
+	myInt64Header    = "RABBITIO.amqp.headers.int.myInt64Header"
+	myFloat32Header  = "RABBITIO.amqp.headers.float.myFloat32Header"
+	myFloat64Header  = "RABBITIO.amqp.headers.float.myFloat64Header"
+	myBoolHeader     = "RABBITIO.amqp.headers.bool.myBoolHeader"
 )
 
 func TestToPAXRecords(t *testing.T) {
 	messageHeaders := make(amqp.Table)
 	messageHeaders["myStringHeader"] = "myString"
+	messageHeaders["myStringEqHeader"] = "my=String"
 	messageHeaders["myInt32Header"] = int32(32)
 	messageHeaders["myInt64Header"] = int64(64)
 	messageHeaders["myFloat32Header"] = float32(32.32)
@@ -42,6 +44,7 @@ func TestToPAXRecords(t *testing.T) {
 
 	var attrHeaders = make(map[string]string)
 	attrHeaders[myStringHeader] = "myString"
+	attrHeaders[myStringEqHeader] = "my=String"
 	attrHeaders[myInt32Header] = "32"
 	attrHeaders[myInt64Header] = "64"
 	attrHeaders[myFloat32Header] = "32.32"
@@ -53,6 +56,7 @@ func TestToPAXRecords(t *testing.T) {
 	assert.NoError(t, messageHeaders.Validate(), "should be valid Headers")
 
 	assert.Equal(t, attrHeaders[myStringHeader], pax[myStringHeader])
+	assert.Equal(t, attrHeaders[myStringEqHeader], pax[myStringEqHeader])
 	assert.Equal(t, attrHeaders[myInt32Header], pax[myInt32Header])
 	assert.Equal(t, attrHeaders[myInt64Header], pax[myInt64Header])
 	assert.Equal(t, attrHeaders[myFloat32Header], pax[myFloat32Header])
@@ -62,8 +66,9 @@ func TestToPAXRecords(t *testing.T) {
 
 func TestNewMessage(t *testing.T) {
 	var headers = make(map[string]string)
-	headers["RABBITIO.amqp.routingKey"] = "routingKey from tarball PAXRecords"
+	headers["RABBITIO.amqp.routingkey"] = "routingKey from tarball PAXRecords"
 	headers[myStringHeader] = "myString"
+	headers[myStringEqHeader] = "my=String"
 	headers[myInt32Header] = "3232"
 	headers[myInt64Header] = "6464"
 	headers[myFloat32Header] = "32.123"


### PR DESCRIPTION
In some tar archiving tools, (gnu tar) it will complain about unsupported format, when using customized PAX string. Avoiding this issue by keeping it in Xattrs for now.

Reference: https://golang.org/pkg/archive/tar/#Header