### PR TITLE
Add blogpost link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ To learn more about common problems with queue management and our reasoning and 
 ## Installing
 
 #### Download binary
+
 Pick your binary from [Releases](https://github.com/meltwater/rabbitio/releases) and download, in addition you'll need to set the binary to be executable.
 
 Example with `linux-amd64` and version `v0.5.3`:
@@ -27,7 +28,7 @@ go get -u github.com/meltwater/rabbitio
 
 ## How to use RabbitIO
 
-After installing rabbitio, you can quickly test out `rabbitio` by using [docker-compose](https://docs.docker.com/compose/install/)
+After installing rabbitio, you can quickly test out `rabbitio` by using [docker-compose](https://docs.docker.com/compose/install/).
 
 Included is a docker-compose file to set up local rabbitmq.
 
@@ -36,8 +37,7 @@ cd $GOPATH/src/github.com/meltwater
 docker-compose up -d
 ```
 
-Go to your now running [local rabbit](http://localhost:15672) and create example exchange: `rabbitio-exchange` and queue `rabbitio-queue`,
-then bind the queue to the exchange.
+Go to your now running [local rabbit](http://localhost:15672) and create example exchange `rabbitio-exchange` and queue `rabbitio-queue`. Then bind the queue to the exchange.
 
 #### Publish your first message
 
@@ -60,10 +60,11 @@ $ rabbitio out -e rabbitio-exchange -q rabbitio-queue -d data/
 2018/03/15 15:37:45 Wrote 203 bytes to data/1_messages_1.tgz
 2018/03/15 15:37:45 tarball writer closing
 ```
+
 We interrupt when the queue is empty by directly using a combination of `CTRL + C` once. This will save the last bits and ack the message.
 
-
 ## Detailed Usage
+
 ```
 $ rabbitio
 Rabbit IO will help backup and restore your messages in RabbitMQ
@@ -91,23 +92,20 @@ Use "rabbitio [command] --help" for more information about a command.
 
 ### AMQP Headers and Routing Key
 
-When you read messages from a queue, the headers as well as the routing key will be saved as metadata in the tarballs,
-utilizing what in tar is called PAX Records. This is helpful if you one day want to replay the data back into the original queue, while keeping the attributes that belong to the message.
-
+When you read messages from a queue, the headers as well as the routing key will be saved as metadata in the tarballs, utilizing what in tar is called PAX Records. This is helpful if you one day want to replay the data back into the original queue, while keeping the attributes that belong to the message.
 
 |    Header Format   |                AMQP Headers               |   Tar PAX Records  |
 |:------------------:|:-----------------------------------------:|:------------------:|
 | Format Translation | map[String] Bool, Integer, String, Float  | map[String] String |
 | Body Type          | Bytes                                     | Bytes              |
 
-The tar metadata can be accessed using [pax](https://linux.die.net/man/1/pax)
+The tar metadata can be accessed using [pax](https://linux.die.net/man/1/pax):
+
 ```bash
 pax -r -zf 1_message_100.tgz
 ```
 
-This will output the messages and in addition a `PaxHeaders.0` directory containing identical filenames as the messages, enabling access of the metadata.
-right now there is no way to selectively publish only certain messages containing a header value, this is a planned feature.
-
+This will output the messages and in addition a `PaxHeaders.0` directory containing identical filenames as the messages, enabling access of the metadata. Right now there is no way to selectively publish only certain messages containing a header value, this is a planned feature.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@
 # RabbitIO
 [![Build Status](https://travis-ci.org/meltwater/rabbitio.svg?branch=master)](https://travis-ci.org/meltwater/rabbitio)
 
-This is a tool to support backup and restoring of RabbitMQ messages
+RabbitIO is a tool to backup and restore RabbitMQ messages. 
+
+To learn more about common problems with queue management and our reasoning and design principles when building RabbitIO, please read this [blog post](https://underthehood.meltwater.com/blog/2018/08/03/rabbitio-a-tool-to-backup-and-restore-messages-from-rabbitmq/).
 
 ## Installing
 


### PR DESCRIPTION
Adds a link to [this blog post](https://underthehood.meltwater.com/blog/2018/08/03/rabbitio-a-tool-to-backup-and-restore-messages-from-rabbitmq/) to the intro of the README.

While at it, I also fixed some other minor formatting issues.