### PR TITLE
Add AWS helper module that uploads saved files to S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Flags:
   -r, --routingkey string   Routing Key, if specified will override tarball routing key configuration (default "#")
   -t, --tag string          AMQP Client Tag (default "Rabbit IO Connector ")
   -u, --uri string          AMQP URI, uri to for instance RabbitMQ (default "amqp://guest:guest@localhost:5672/")
+  -s, --s3Bucket string     S3 bucket to uplaod files to
+  -k, --awsKey string       AWS Key Credential
+  -w, --awsSecret string    AWS Secret Credential
 
 Use "rabbitio [command] --help" for more information about a command.
 ```

--- a/awshelper/aws_helper.go
+++ b/awshelper/aws_helper.go
@@ -1,0 +1,111 @@
+// Copyright © 2020 Meltwater
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package awshelper
+
+import (
+	"bytes"
+	"errors"
+	"log"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+)
+
+var (
+	s3Bucket, awsKey, awsSecret string
+)
+
+func NewAWSHelper(awsKeyID string, awsSecretAcessKey string, awsS3Bucket string) {
+	s3Bucket = awsS3Bucket
+	awsKey = awsKeyID
+	awsSecret = awsSecretAcessKey
+}
+
+func UploadToS3(path string) (string, error) {
+	// If AWS credentials were not passed as args, skip uploading to S3
+	if len(strings.TrimSpace(awsKey)) == 0 || len(strings.TrimSpace(awsSecret)) == 0 || len(strings.TrimSpace(s3Bucket)) == 0 {
+		return "", errors.New("Empty or Invalid AWS Credentials, Skipping S3 Uploads..")
+	}
+
+	// All clients require a Session. The Session provides the client with
+	// shared configuration such as region, endpoint, and credentials. A
+	// Session should be shared where possible to take advantage of
+	// configuration and credential caching. See the session package for
+	// more information.
+	sess := session.Must(session.NewSession(
+		&aws.Config{
+			Region: aws.String("us-west-2"),
+			Credentials: credentials.NewStaticCredentials(
+				awsKey,
+				awsSecret,
+				"", // a token will be created when the session is used.
+			),
+		}),
+	)
+
+	// Open the file for use
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+
+	// Get file size and read the file content into a buffer
+	fileInfo, _ := file.Stat()
+	var size int64 = fileInfo.Size()
+	buffer := make([]byte, size)
+	file.Read(buffer)
+
+	// Create a new instance of the service's client with a Session.
+	// Optional aws.Config values can also be provided as variadic arguments
+	// to the New function. This option allows you to provide service
+	// specific configuration.
+	svc := s3.New(sess)
+
+	// Uploads the object to S3. Config settings: this is where you choose the bucket,
+	// filename, content-type and storage class of the file you're uploading
+	_, err = svc.PutObject(&s3.PutObjectInput{
+		Bucket:               aws.String(s3Bucket),
+		Key:                  aws.String(path),
+		Body:                 bytes.NewReader(buffer),
+		ACL:                  aws.String("private"),
+		ContentType:          aws.String(http.DetectContentType(buffer)),
+		ContentLength:        aws.Int64(int64(size)),
+		ContentDisposition:   aws.String("attachment"),
+		ServerSideEncryption: aws.String("AES256"),
+		StorageClass:         aws.String("INTELLIGENT_TIERING"),
+	})
+
+	if err != nil {
+		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == request.CanceledErrorCode {
+			// If the SDK can determine the request or retry delay was canceled
+			// by a context the CanceledErrorCode error code will be returned.
+			log.Fatalf("Upload canceled due to timeout, %s\n", err)
+		} else {
+			log.Fatalf("Failed to upload object, %s\n", err)
+		}
+		return "", err
+	}
+
+	log.Printf("successfully uploaded file to %s/%s\n", s3Bucket, path)
+	return path, nil
+}

--- a/cmd/out.go
+++ b/cmd/out.go
@@ -20,6 +20,7 @@ import (
 	"os/signal"
 	"syscall"
 
+	"github.com/meltwater/rabbitio/awshelper"
 	"github.com/meltwater/rabbitio/file"
 	"github.com/meltwater/rabbitio/rmq"
 	"github.com/spf13/cobra"
@@ -46,6 +47,8 @@ var outCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+
+		awshelper.NewAWSHelper(awsKey, awsSecret, s3Bucket)
 
 		go rabbit.Consume(channel, verify)
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,9 +22,9 @@ import (
 )
 
 var (
-	version                               string
-	uri, exchange, queue, tag, routingKey string
-	prefetch                              int
+	version                                                            string
+	uri, exchange, queue, tag, routingKey, s3Bucket, awsKey, awsSecret string
+	prefetch                                                           int
 )
 
 // RootCmd represents the base command when called without any subcommands
@@ -52,5 +52,8 @@ func init() {
 	RootCmd.PersistentFlags().StringVarP(&queue, "queue", "q", "", "Queue to connect to")
 	RootCmd.PersistentFlags().StringVarP(&routingKey, "routingkey", "r", "#", "Routing Key, if specified will override tarball routing key configuration")
 	RootCmd.PersistentFlags().StringVarP(&tag, "tag", "t", "Rabbit IO Connector "+version, "AMQP Client Tag")
+	RootCmd.PersistentFlags().StringVarP(&s3Bucket, "s3Bucket", "s", "", "S3 bucket to uplaod files to")
+	RootCmd.PersistentFlags().StringVarP(&awsKey, "awsKey", "k", "", "AWS Key Credential")
+	RootCmd.PersistentFlags().StringVarP(&awsSecret, "awsSecret", "w", "", "AWS Secret Credential")
 	RootCmd.PersistentFlags().IntVarP(&prefetch, "prefetch", "p", 100, "Prefetch for batches")
 }

--- a/file/tarball.go
+++ b/file/tarball.go
@@ -21,9 +21,11 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"path/filepath"
 	"sync"
 	"time"
 
+	"github.com/meltwater/rabbitio/awshelper"
 	"github.com/meltwater/rabbitio/rmq"
 	"github.com/pborman/uuid"
 	"github.com/spf13/afero"
@@ -142,7 +144,8 @@ func (t *TarballBuilder) Pack(messages chan rmq.Message, dir string, verify chan
 			t.gzip.Close()
 
 			// writes to tarball here when reached the t.tarSize
-			err := writeFile(t.buf.Bytes(), dir, fmt.Sprintf("%d_messages_%d.tgz", fileNum, docNum))
+			fileName := fmt.Sprintf("%s_%d_messages_%d.tgz", time.Now().String(), fileNum, docNum)
+			err := writeFile(t.buf.Bytes(), dir, fileName)
 			if err != nil {
 				return err
 			}
@@ -153,6 +156,9 @@ func (t *TarballBuilder) Pack(messages chan rmq.Message, dir string, verify chan
 				return err
 			}
 			docNum = 0
+
+			// upload file to S3
+			awshelper.UploadToS3(filepath.Join(dir, fileName))
 		}
 
 		if err := t.addFile(t.tar, uuid.New()+".rio", &doc); err != nil {
@@ -166,10 +172,14 @@ func (t *TarballBuilder) Pack(messages chan rmq.Message, dir string, verify chan
 	fileNum++
 
 	// writes to tarball here when not reached the t.tarSize
-	err := writeFile(t.buf.Bytes(), dir, fmt.Sprintf("%d_messages_%d.tgz", fileNum, docNum))
+	fileName := fmt.Sprintf("%s_%d_messages_%d.tgz", time.Now().String(), fileNum, docNum)
+	err := writeFile(t.buf.Bytes(), dir, fileName)
 	if err != nil {
 		return err
 	}
+
+	// upload file to S3
+	awshelper.UploadToS3(filepath.Join(dir, fileName))
 
 	// Does not ack the messages unless it is repeated, not sure why yet..
 	// Might want to change using delivery ack interface


### PR DESCRIPTION
**Description:**

Creating an AWS module that gets its configuration through CMD parameters (AWS KEY, SECRET and S3Bucket), that uploads the file (once saved) into S3 into a custom bucket path (e.g: https://s3.console.aws.amazon.com/s3/buckets/rabbitmq-backups-rabbitio/?region=us-west-2&tab=overview)

**Testing:**
- Ran `go build -a` --> gets a binary out `rabbitio`
- Ran `./rabbitio out -e staging -q test-rabbitio -u amqp://<username>:<password>@rabbitmq-staging.ucoachapp.com:5672 --awsKey <aws_key> --awsSecret <aws_secret> --s3Bucket rabbitmq-backups-rabbitio`

- 
![Screen Shot 2020-09-24 at 5 04 20 PM](https://user-images.githubusercontent.com/1479894/94165360-6912c080-fe8a-11ea-9b33-2c1f625d22b0.png)

- Messages uploaded successfully to S3:
![Screen Shot 2020-09-24 at 5 21 58 PM](https://user-images.githubusercontent.com/1479894/94165429-7e87ea80-fe8a-11ea-8534-6953471ee051.png)
